### PR TITLE
Converted server side supabase to use service role instead

### DIFF
--- a/src/actions/submitContactForm.ts
+++ b/src/actions/submitContactForm.ts
@@ -1,4 +1,5 @@
 'use server';
+
 import { discordNewError, discordNewMessage } from '@/libs/discord/actions';
 import { dbPostContact } from '@/libs/supabase/actions';
 import { ContactSchema, type ContactInput } from '@/validation/contactForm';

--- a/src/libs/supabase/actions.ts
+++ b/src/libs/supabase/actions.ts
@@ -1,4 +1,6 @@
-import { supabase } from "@/libs/supabase/client"
+"use server"
+
+import { supabaseAdmin } from "@/libs/supabase/client"
 import { Contact } from "@/validation/contactForm"
 
 export async function dbPostContact(contact: Contact) {
@@ -7,7 +9,7 @@ export async function dbPostContact(contact: Contact) {
     const { hp, ...contactCleaned } = contact
 
     // Attempt db insert, id and created_at will be filled automatically
-    const { data, error } = await supabase.from("contacts").insert(contactCleaned).select()
+    const { data, error } = await supabaseAdmin.from("contacts").insert(contactCleaned).select()
 
     // Propigate errors to caller
     if (error) {

--- a/src/libs/supabase/client.ts
+++ b/src/libs/supabase/client.ts
@@ -1,6 +1,14 @@
 import { Database } from '@/types/supabase.types'
 import { createClient } from '@supabase/supabase-js'
 
-export const supabase = createClient<Database>(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!)
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+export const supabaseAdmin = createClient<Database>(supabaseUrl!, supabaseServiceKey!, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+})
 
 


### PR DESCRIPTION
As part of locking down the database now that I've tested what I wanted we can switch to a production role. This PR changes the key used when creating the supabase client from anon to service role. All consumers has been flagged with `use server` directive