### PR TITLE
Improvements to mobile navigation main menu

### DIFF
--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -191,3 +191,8 @@
 .grecaptcha-badge {
   visibility: hidden !important;
 }
+
+/* This class stops global scroll, add to any modals if needed */
+:root:has(.stop-scroll) {
+  overflow: hidden;
+}

--- a/src/components/layout/base/header.tsx
+++ b/src/components/layout/base/header.tsx
@@ -4,8 +4,6 @@ import Link from 'next/link';
 import { cookies } from 'next/headers';
 import { NavigationDesktop } from '@/components/layout/navigation/desktop';
 import { NavigationMobile } from '@/components/layout/navigation/mobile';
-import { HeaderMenuTheme } from '@/components/ui/menus/HeaderThemeMenu';
-import { HeaderMenuLocale } from '@/components/ui/menus/HeaderLocaleMenu';
 
 export async function Header() {
   const theme = ((await cookies()).get('theme')?.value as ThemeOptions) || 'system';
@@ -24,12 +22,8 @@ export async function Header() {
             Home
           </p>
         </Link>
-        <NavigationDesktop />
-        <span className='flex-1 flex justify-end-safe items-center gap-6'>
-          <HeaderMenuTheme current={theme} />
-          <HeaderMenuLocale />
-          <NavigationMobile />
-        </span>
+        <NavigationDesktop current={theme} />
+        <NavigationMobile current={theme} />
       </div>
     </header>
   );

--- a/src/components/layout/navigation/desktop.tsx
+++ b/src/components/layout/navigation/desktop.tsx
@@ -1,16 +1,25 @@
+import { ThemeOptions } from '@/actions/changeTheme';
+import { HeaderMenuLocale } from '@/components/ui/menus/HeaderLocaleMenu';
+import { HeaderMenuTheme } from '@/components/ui/menus/HeaderThemeMenu';
 import menuLinks from '@/data/navigation/links.json';
+import { useLocale } from 'next-intl';
 import Link from 'next/link';
 
-export function NavigationDesktop() {
+export function NavigationDesktop({ current }: { current: ThemeOptions }) {
+  const locale = useLocale() as 'en' | 'no';
   return (
-    <nav className='hidden sm:block'>
-      <ul className='flex justify-around gap-4'>
+    <>
+      <nav className='hidden sm:flex justify-around gap-4'>
         {menuLinks.map((item) => (
-          <Link key={'navbar-desktop-' + item.label} href={item.href} scroll>
-            {item.label}
+          <Link key={'navbar-desktop-' + item.label[locale]} href={item.href} scroll>
+            {item.label[locale]}
           </Link>
         ))}
-      </ul>
-    </nav>
+      </nav>
+      <span className='hidden sm:flex flex-1 justify-end-safe items-center gap-6'>
+        <HeaderMenuTheme current={current} />
+        <HeaderMenuLocale />
+      </span>
+    </>
   );
 }

--- a/src/components/layout/navigation/mobile.tsx
+++ b/src/components/layout/navigation/mobile.tsx
@@ -5,39 +5,46 @@ import Link from 'next/link';
 import { useRef, useState } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { HamburgerIcon } from '@/components/ui/icons/Hamburger';
-import { Globe } from 'lucide-react';
+import { MobileMenuLanguageSelect } from '@/components/ui/menus/mobile/MenuLanguageSelect';
+import { MobileMenuAppearanceToggle } from '@/components/ui/menus/mobile/MenuAppearanceToggle';
+import { ThemeOptions } from '@/actions/changeTheme';
+import { useLocale } from 'next-intl';
 
-export function NavigationMobile() {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLElement>(null);
+export function NavigationMobile({ current }: { current: ThemeOptions }) {
+  const [isOpen, setIsOpen] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setIsOpen(false));
 
+  const locale = useLocale() as 'en' | 'no';
+
   return (
-    <nav ref={containerRef} className={`sm:hidden ${isOpen ? 'stop-scroll' : ''}`}>
-      <HamburgerIcon active={isOpen} onClick={() => setIsOpen(!isOpen)} />
+    <div ref={containerRef} className={`sm:hidden ${isOpen ? 'stop-scroll' : ''}`}>
+      <HamburgerIcon active={isOpen} onClick={() => setIsOpen(!isOpen)} className='size-8' />
       <div
         className={`
           fixed inset-0 top-20 flex flex-col
           ${isOpen ? '' : 'translate-x-full'}
-          backdrop-blur-md backdrop-brightness-50 transition-transform
+          backdrop-blur-xl backdrop-brightness-40  transition-transform
+          overflow-y-auto
         `}
       >
         <nav className='flex-1 flex flex-col items-center justify-center gap-4 p-4'>
           {menuLinks.map((item) => (
-            <Link href={item.href} key={'navbar-desktop-' + item.label}>
-              {item.label}
+            <Link
+              href={item.href}
+              key={'navbar-desktop-' + item.label[locale]}
+              className='uppercase text-2xl/loose text-white'
+              onClick={() => setIsOpen(false)}
+            >
+              {item.label[locale]}
             </Link>
           ))}
         </nav>
-        <div className='bg-panel flex flex-col gap-4'>
-          <div>
-            <span className='flex gap-2'>
-              <Globe />
-              <h3>Language</h3>
-            </span>
-          </div>
+        <div className='bg-background flex flex-col gap-8 p-8'>
+          <MobileMenuLanguageSelect />
+          <MobileMenuAppearanceToggle current={current} />
         </div>
       </div>
-    </nav>
+    </div>
   );
 }

--- a/src/components/layout/navigation/mobile.tsx
+++ b/src/components/layout/navigation/mobile.tsx
@@ -1,9 +1,11 @@
-"use client";
+'use client';
 
-import menuLinks from "@/data/navigation/links.json";
-import Link from "next/link";
-import { useRef, useState } from "react";
-import { useClickOutside } from "@/hooks/useClickOutside";
+import menuLinks from '@/data/navigation/links.json';
+import Link from 'next/link';
+import { useRef, useState } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import { HamburgerIcon } from '@/components/ui/icons/Hamburger';
+import { Globe } from 'lucide-react';
 
 export function NavigationMobile() {
   const [isOpen, setIsOpen] = useState(false);
@@ -11,22 +13,31 @@ export function NavigationMobile() {
   useClickOutside(containerRef, () => setIsOpen(false));
 
   return (
-    <nav ref={containerRef} className="sm:hidden">
-      <button onClick={() => setIsOpen(!isOpen)}>🍞</button>
-      <ul
+    <nav ref={containerRef} className={`sm:hidden ${isOpen ? 'stop-scroll' : ''}`}>
+      <HamburgerIcon active={isOpen} onClick={() => setIsOpen(!isOpen)} />
+      <div
         className={`
-          fixed inset-0 top-20
-          flex flex-col items-center justify-center gap-4 p-4
-          ${isOpen ? "" : "translate-x-full"}
+          fixed inset-0 top-20 flex flex-col
+          ${isOpen ? '' : 'translate-x-full'}
           backdrop-blur-md backdrop-brightness-50 transition-transform
         `}
       >
-        {menuLinks.map((item) => (
-          <li key={"navbar-desktop-" + item.label}>
-            <Link href={item.href}>{item.label}</Link>
-          </li>
-        ))}
-      </ul>
+        <nav className='flex-1 flex flex-col items-center justify-center gap-4 p-4'>
+          {menuLinks.map((item) => (
+            <Link href={item.href} key={'navbar-desktop-' + item.label}>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className='bg-panel flex flex-col gap-4'>
+          <div>
+            <span className='flex gap-2'>
+              <Globe />
+              <h3>Language</h3>
+            </span>
+          </div>
+        </div>
+      </div>
     </nav>
   );
 }

--- a/src/components/layout/navigation/mobile.tsx
+++ b/src/components/layout/navigation/mobile.tsx
@@ -11,7 +11,7 @@ import { ThemeOptions } from '@/actions/changeTheme';
 import { useLocale } from 'next-intl';
 
 export function NavigationMobile({ current }: { current: ThemeOptions }) {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setIsOpen(false));
 

--- a/src/components/ui/icons/Hamburger.tsx
+++ b/src/components/ui/icons/Hamburger.tsx
@@ -1,0 +1,45 @@
+import { ComponentProps, ComponentPropsWithoutRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface HamburgerIconProps extends ComponentProps<'svg'> {
+  active?: boolean;
+}
+
+export function HamburgerIcon({ active, className, ...props }: HamburgerIconProps) {
+  const pathClass: ComponentPropsWithoutRef<'path'>['className'] =
+    'bg-primary fill-none stroke-current stroke-3 [transition:stroke-dasharray_0.3s_cubic-bezier(0.645,0.045,0.355,1),stroke-dashoffset_0.3s_cubic-bezier(0.645,0.045,0.355,1)]';
+
+  return (
+    <svg
+      viewBox='35 50 30 1'
+      xmlns='http://www.w3.org/2000/svg'
+      className={twMerge('size-6 overflow-visible fill-text hover:fill-primary-hover', className)}
+      {...props}
+    >
+      <path
+        className={twMerge(pathClass, ``)}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeDasharray={active ? '22, 126' : '24, 126'}
+        strokeDashoffset={active ? -94 : -38}
+        d='M0 40h62c13 0 6 28-4 18L35 35'
+      />
+      <path
+        className={twMerge(pathClass, ``)}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeDasharray={active ? '0, 70' : '24, 70'}
+        strokeDashoffset={active ? -50 : -38}
+        d='M0 50h70'
+      />
+      <path
+        className={twMerge(pathClass, ``)}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeDasharray={active ? '22, 126' : '24, 126'}
+        strokeDashoffset={active ? -94 : -38}
+        d='M0 60h62c13 0 6-28-4-18L35 65'
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/menus/mobile/MenuAppearanceToggle.tsx
+++ b/src/components/ui/menus/mobile/MenuAppearanceToggle.tsx
@@ -1,0 +1,48 @@
+import { type ReactElement } from 'react';
+import { changeTheme, type ThemeOptions } from '@/actions/changeTheme';
+import { MonitorCog, Moon, Sun, SunMoon } from 'lucide-react';
+import { IconButton } from '@/components/ui/buttons/IconButton';
+
+export function MobileMenuAppearanceToggle({ current }: { current: ThemeOptions }) {
+  // Grouping the available themes in an option
+  const options: Record<ThemeOptions, ReactElement> = {
+    dark: <Moon />,
+    light: <Sun />,
+    system: <MonitorCog />,
+  };
+
+  // Helpers for calculating moving background
+  const keys = Object.keys(options) as ThemeOptions[];
+  const activeIndex = keys.indexOf(current);
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <span className='flex gap-2'>
+        <SunMoon />
+        <h2>Appearance</h2>
+      </span>
+      <span className='panel relative grid grid-cols-3 rounded-full p-1 overflow-hidden'>
+        <span
+          aria-hidden='true'
+          className='absolute inset-y-1 left-1 rounded-full bg-primary transition-transform duration-300 ease-out'
+          style={{
+            width: 'calc((100% - 0.5rem) / 3)',
+            transform: `translateX(${activeIndex * 100}%)`,
+          }}
+        />
+        {keys.map((theme) => (
+          <IconButton
+            key={theme}
+            icon={options[theme]}
+            label={theme}
+            onClick={() => changeTheme(theme)}
+            className={`
+              relative z-10 w-full justify-center rounded-full bg-transparent py-1 px-4
+              ${current === theme ? 'text-primary-foreground' : ''}
+            `}
+          />
+        ))}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ui/menus/mobile/MenuLanguageSelect.tsx
+++ b/src/components/ui/menus/mobile/MenuLanguageSelect.tsx
@@ -20,6 +20,7 @@ export function MobileMenuLanguageSelect() {
       </span>
       <select
         className='relative p-2 panel'
+        defaultValue={current}
         onChange={(e) => {
           changeLocale(e.currentTarget.value as Locales);
         }}

--- a/src/components/ui/menus/mobile/MenuLanguageSelect.tsx
+++ b/src/components/ui/menus/mobile/MenuLanguageSelect.tsx
@@ -1,0 +1,35 @@
+import { changeLocale, Locales } from '@/actions/changeLocale';
+import { Globe } from 'lucide-react';
+import { useLocale } from 'next-intl';
+
+export function MobileMenuLanguageSelect() {
+  // Get the current locale for displaying correct active icon
+  const current = useLocale();
+
+  // Grouping the available languages in an option
+  const options: Record<Locales, { label: string }> = {
+    en: { label: 'English' },
+    no: { label: 'Norsk' },
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <span className='flex gap-2'>
+        <Globe />
+        <h2>Language</h2>
+      </span>
+      <select
+        className='relative p-2 panel'
+        onChange={(e) => {
+          changeLocale(e.currentTarget.value as Locales);
+        }}
+      >
+        {Object.keys(options).map((locale) => (
+          <option key={locale} value={locale}>
+            {options[locale as Locales].label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/data/navigation/links.json
+++ b/src/data/navigation/links.json
@@ -1,26 +1,30 @@
 [
   {
-    "label": "Projects",
-    "href": "/#projects"
+    "href": "/",
+    "label": {
+      "en": "Landing page",
+      "no": "Hoved side"
+    }
   },
   {
-    "label": "Donate",
-    "href": "/#donate"
+    "href": "/about",
+    "label": {
+      "en": "About",
+      "no": "Om oss"
+    }
   },
   {
-    "label": "Volunteer",
-    "href": "/#volunteer"
+    "href": "/history",
+    "label": {
+      "en": "History",
+      "no": "Vår historie"
+    }
   },
   {
-    "label": "Gallery",
-    "href": "/#gallery"
-  },
-  {
-    "label": "History",
-    "href": "/history"
-  },
-  {
-    "label": "About",
-    "href": "/about"
+    "href": "/#contact",
+    "label": {
+      "en": "Contact us",
+      "no": "Kontakt oss"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Updated the main menu in the header to be better on mobile devices.

## Related issue

- resolves #55 

## What was changed

- Improved the design of mobile menu section by adding dedicated components following the design requirements stated in #55
- Moved the default language and appearance menus into the desktop/mobile menu variations so that they could decide on what to show.
- `src/data/navigation/links.json` had their structure changed to support `i18n`, see below
  ```diff
  {
      "href": "/",
  -   "label": "Landing page",
  +   "label": {
  +     "en": "Landing page",
  +     "no": "Hoved side"
  +   }
  },
  ```

## Scope of review

Click on all the buttons, try to change between the modes while you're using it

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
