### PR TITLE
Removing text overflow in footers contact section

### DIFF
--- a/src/components/layout/base/footer.tsx
+++ b/src/components/layout/base/footer.tsx
@@ -10,69 +10,67 @@ export function Footer() {
     <footer className='bg-black/50'>
       <div className='container mx-auto px-4 py-8 lg:py-16 grid gap-16 grid-cols-1 lg:grid-cols-2'>
         <div className='flex flex-col gap-4'>
-          <h2>{t("followUs.title")}</h2>
+          <h2>{t('followUs.title')}</h2>
           <div className='flex gap-4'>
             <SocialButton href='https://github.com/kunkristoffer/Bathybiologica' />
             <SocialButton href='https://www.bathybiologica.com/' />
           </div>
         </div>
         <div className='flex flex-col gap-4'>
-          <h2>{t("newsletter.title")}</h2>
+          <h2>{t('newsletter.title')}</h2>
           <span className='flex items-center border border-input focus-within:border-primary'>
             <input
               type='email'
               className='flex-1 p-2 appearance-none'
-              placeholder={t("newsletter.placeholder")}
+              placeholder={t('newsletter.placeholder')}
               disabled
             />
             <ScrollText className='m-2' />
           </span>
-          <p className='italic text-text-muted'>{t("newsletter.comingSoon")}</p>
+          <p className='italic text-text-muted'>{t('newsletter.comingSoon')}</p>
         </div>
       </div>
       <div className='container mx-auto px-4 py-8 lg:py-16 grid gap-16 grid-cols-2 lg:grid-cols-4'>
         <div className='flex flex-col gap-4'>
-          <h2>{t("mission.title")}</h2>
-          <small>{t("mission.text")}</small>
+          <h2>{t('mission.title')}</h2>
+          <small>{t('mission.text')}</small>
         </div>
         <div className='flex flex-col gap-4'>
-          <h2>{t("sitemap.title")}</h2>
+          <h2>{t('sitemap.title')}</h2>
           <nav className='flex flex-col'>
-            <Link href='/'>{t("sitemap.landing")}</Link>
-            <Link href='/about'>{t("sitemap.about")}</Link>
-            <Link href='/history'>{t("sitemap.history")}</Link>
+            <Link href='/'>{t('sitemap.landing')}</Link>
+            <Link href='/about'>{t('sitemap.about')}</Link>
+            <Link href='/history'>{t('sitemap.history')}</Link>
           </nav>
         </div>
         <div className='flex flex-col gap-4'>
-          <h2>{t("links.title")}</h2>
+          <h2>{t('links.title')}</h2>
           <nav className='flex flex-col'>
-            <p>{t("links.login")}</p>
-            <p>{t("links.dashboard")}</p>
-            <p>{t("links.events")}</p>
-            <p>{t("links.inbox")}</p>
+            <p>{t('links.login')}</p>
+            <p>{t('links.dashboard')}</p>
+            <p>{t('links.events')}</p>
+            <p>{t('links.inbox')}</p>
           </nav>
-          <p className='italic text-text-muted'>{t("links.comingSoon")}</p>
+          <p className='italic text-text-muted'>{t('links.comingSoon')}</p>
         </div>
         <div className='flex flex-col gap-4'>
-          <h2>{t("contact.title")}</h2>
+          <h2>{t('contact.title')}</h2>
           <IconLink
             href='mailto:contact@bathybiologica.com'
             label='contact@bathybiologica.com'
             icon={<Mail />}
             className='hidden'
           />
-          <p className='text-sm/normal'>
-            {t("contact.p1")}
-            <Link href='/#contact' className='px-1'>{t("contact.label")}</Link>
-            {t("contact.p2")}
+          <p className='text-sm/normal wrap-break-word'>
+            {t('contact.p1')} <Link href='/#contact'>{t('contact.label')}</Link> {t('contact.p2')}
           </p>
         </div>
       </div>
       <div className='bg-black/40'>
         <div className='container mx-auto flex justify-between items-center p-4'>
-          <p className='text-sm/tight'>{t("bottom.copyright")}</p>
+          <p className='text-sm/tight'>{t('bottom.copyright')}</p>
           <Link href='/privacy' className='text-sm/tight'>
-            {t("bottom.privacy")}
+            {t('bottom.privacy')}
           </Link>
         </div>
       </div>

--- a/src/data/content/en.json
+++ b/src/data/content/en.json
@@ -66,8 +66,8 @@
     },
     "contact": {
       "title": "Contact us",
-      "p1": "Please use the",
-      "p2": "it you want to contact us. We are currently working on sitting up different communication channels.",
+      "p1": "We are currently making more contact options available. In the meantime, please use the",
+      "p2": "if you would like to get in touch with us.",
       "label": "contact form"
     },
     "bottom": {

--- a/src/data/content/no.json
+++ b/src/data/content/no.json
@@ -66,8 +66,8 @@
     },
     "contact": {
       "title": "Kontakt oss",
-      "p1": "Vennligst bruk",
-      "p2": "dersom du ønsker å kontakte oss. Vi jobber for tiden med å sette opp ulike kommunikasjonskanaler.",
+      "p1": "Vi holder på å gjøre flere kontaktmuligheter tilgjengelige. Inntil videre ber vi deg bruke",
+      "p2": "dersom du ønsker å komme i kontakt med oss",
       "label": "kontaktskjemaet"
     },
     "bottom": {


### PR DESCRIPTION
## Summary

Fixed text overflowing which was adding horizontal scrolling to the whole page

## Related issue

- fixes #110 

## What was changed

- Added propper text break to the contact section
- Updated the language used in this section
- Applied prettier formatting, which is why the diff is such a mess...

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
