### PR TITLE
Improving page paddings

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export default async function Privacy() {
   const messages = await getMessages();
   const privacy = messages.privacy as PrivacyMessages;
   return (
-    <main className='relative sm:flex-row gap-4 p-4'>
+    <main className='relative sm:flex-row gap-4 p-4 md:px-8'>
       <TableOfContents headingLevels={['h2', 'h3', 'h4']} />
       <div className='flex flex-col gap-12'>
         {privacy.sections.map((data, i) => (

--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -90,7 +90,7 @@
 
   header > :first-child {
     height: var(--header-h);
-    @apply container mx-auto flex justify-between items-center p-4;
+    @apply container mx-auto flex justify-between items-center p-4 md:px-8;
   }
 
   main > section > :first-child {
@@ -98,6 +98,8 @@
   }
 
   footer {
+    @apply px-4 py-8 md:px-8 lg:py-16 grid gap-16;
+
     a {
       @apply text-primary;
     }

--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -93,12 +93,14 @@
     @apply container mx-auto flex justify-between items-center p-4 md:px-8;
   }
 
-  main > section > :first-child {
-    @apply container mx-auto flex flex-col px-4 py-16 lg:py-24;
+  main > section > div {
+    @apply container mx-auto flex flex-col px-4 md:px-8 py-16 lg:py-24;
   }
 
   footer {
-    @apply px-4 py-8 md:px-8 lg:py-16 grid gap-16;
+    > div {
+      @apply px-4 py-8 md:px-8 lg:py-16 grid gap-16;
+    }
 
     a {
       @apply text-primary;

--- a/src/components/layout/base/footer.tsx
+++ b/src/components/layout/base/footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
   const t = useTranslations('layout.footer');
   return (
     <footer className='bg-black/50'>
-      <div className='container mx-auto px-4 py-8 lg:py-16 grid gap-16 grid-cols-1 lg:grid-cols-2'>
+      <div className='container mx-auto grid-cols-1 lg:grid-cols-2'>
         <div className='flex flex-col gap-4'>
           <h2>{t('followUs.title')}</h2>
           <div className='flex gap-4'>

--- a/src/components/layout/base/footer.tsx
+++ b/src/components/layout/base/footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
           <p className='italic text-text-muted'>{t('newsletter.comingSoon')}</p>
         </div>
       </div>
-      <div className='container mx-auto px-4 py-8 lg:py-16 grid gap-16 grid-cols-2 lg:grid-cols-4'>
+      <div className='container mx-auto grid gap-16 grid-cols-2 lg:grid-cols-4'>
         <div className='flex flex-col gap-4'>
           <h2>{t('mission.title')}</h2>
           <small>{t('mission.text')}</small>


### PR DESCRIPTION
## Summary

This PR aims to improve the visuals on tablet and higher screen sizes by increasing page padd

## Related issue

<!-- Use closing keywords here: close(es/d), fix(es/d) & resolve(es/d) -->

- closes #121 

## What was changed

- Movet page paddings into global style sheet where it was possisble
- Removed page specifict `px` overrides

## Scope of review

Check all available routes to make sure that all pages follow the same structure
- main `px`  is `4` while `md` or higher has `8`

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
