### PR TITLE
Hide ToC on mobile when not in use

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -8,7 +8,7 @@ export default async function Privacy() {
   const privacy = messages.privacy as PrivacyMessages;
   return (
     <main className='relative sm:flex-row gap-4 p-4 md:px-8'>
-      <TableOfContents containerID='privacy-page' headingLevels={['h2', 'h3', 'h4']} />
+      <TableOfContents containerID='privacy-page' headingLevels={['h2', 'h3', 'h4', 'h5']} />
       <div id='privacy-page' className='flex flex-col gap-12'>
         {privacy.sections.map((data, i) => (
           <PrivacySection key={data.id} level={i === 0 ? 1 : 2} {...data} />

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -8,8 +8,8 @@ export default async function Privacy() {
   const privacy = messages.privacy as PrivacyMessages;
   return (
     <main className='relative sm:flex-row gap-4 p-4 md:px-8'>
-      <TableOfContents headingLevels={['h2', 'h3', 'h4']} />
-      <div className='flex flex-col gap-12'>
+      <TableOfContents containerID='privacy-page' headingLevels={['h2', 'h3', 'h4']} />
+      <div id='privacy-page' className='flex flex-col gap-12'>
         {privacy.sections.map((data, i) => (
           <PrivacySection key={data.id} level={i === 0 ? 1 : 2} {...data} />
         ))}

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -164,7 +164,9 @@ export function TableOfContents({ title, containerID, headingLevels, className }
   }, [containerID, headingLevels]);
 
   return (
-    <aside className={`min-w-48 ${isVisible ? '' : 'hidden'}`}>
+    <aside
+      className={`min-w-48 ${isVisible ? 'opacity-100' : 'max-sm:opacity-0 max-sm:pointer-events-none'} transition duration-100`}
+    >
       <nav
         className={twMerge(
           `z-10 fixed sm:sticky top-[calc(var(--header-h)+1rem)] max-h-[calc(100svh-var(--header-h)-2rem)]

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -82,15 +82,13 @@ export function TableOfContents({ title, containerID, headingLevels, className }
         const containerObserver = headingElementsRef.current.get(containerID)!;
         const { top, height } = containerObserver.target.getBoundingClientRect();
         const diff = (height - Math.abs(top)) / window.innerHeight;
-        setIsVisible(diff >= 1);
-
-        console.log(containerObserver.intersectionRatio);
+        setIsVisible(diff > 1);
       }
 
       // Get the top headings that are visible
       const visibleHeadingsIDs: string[] = [];
       headingElementsRef.current.forEach((entry, id) => {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && entry.target.id !== containerID) {
           visibleHeadingsIDs.push(id);
         }
       });
@@ -141,13 +139,11 @@ export function TableOfContents({ title, containerID, headingLevels, className }
           setActiveID(closestAbove);
         }
       }
-
-      //console.log(visibleHeadingsIDs.length, ...visibleHeadingsIDs);
     };
 
     // Instanciate observer and observe all header elements inside specified container
     observerRef.current = new IntersectionObserver(callback, {
-      rootMargin: `-12px 0px -40% 0px`,
+      rootMargin: `-80px 0px -40% 0px`,
       threshold: [0, 1],
     });
 

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -19,6 +19,11 @@ export interface TableOfContentProps {
 }
 
 export function TableOfContents({ title, containerID, headingLevels, className }: TableOfContentProps) {
+  // Component visibilty
+  const [isVisible, setIsVisible] = useState(true);
+  const containerRef = useRef<IntersectionObserver | null>(null);
+
+  // Heading states
   const [headings, setHeadings] = useState<ToCItem[]>([]);
   const [activeID, setActiveID] = useState('');
   const [expandedIDs, setExpandedIDs] = useState<Set<string>>(new Set());
@@ -123,6 +128,8 @@ export function TableOfContents({ title, containerID, headingLevels, className }
           setActiveID(closestAbove);
         }
       }
+
+      //console.log(visibleHeadingsIDs.length, ...visibleHeadingsIDs);
     };
 
     // Instanciate observer and observe all header elements inside specified container
@@ -138,13 +145,29 @@ export function TableOfContents({ title, containerID, headingLevels, className }
       }
     });
 
+    // Hide ToC when outside query container
+    const containerObserver = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        setIsVisible(entry.isIntersecting);
+      },
+      {
+        rootMargin: '-100% 0px 0px 0px',
+        threshold: 0,
+      }
+    );
+
+    if (containerID) {
+      containerObserver.observe(queryContainer as Element);
+    }
+
     return () => {
-      observerRef.current?.disconnect();
+      (observerRef.current?.disconnect(), containerRef.current?.disconnect());
     };
   }, [containerID, headingLevels]);
 
   return (
-    <aside className='min-w-48'>
+    <aside className={`min-w-48 ${isVisible ? '' : 'hidden'}`}>
       <nav
         className={twMerge(
           `z-10 fixed sm:sticky top-[calc(var(--header-h)+1rem)] max-h-[calc(100svh-var(--header-h)-2rem)]

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -21,7 +21,6 @@ export interface TableOfContentProps {
 export function TableOfContents({ title, containerID, headingLevels, className }: TableOfContentProps) {
   // Component visibilty
   const [isVisible, setIsVisible] = useState(true);
-  const containerRef = useRef<IntersectionObserver | null>(null);
 
   // Heading states
   const [headings, setHeadings] = useState<ToCItem[]>([]);
@@ -67,12 +66,26 @@ export function TableOfContents({ title, containerID, headingLevels, className }
 
     // Create a single array with all heading element IDs, used for lookup and itteration
     const allIDs = getAllIDs(nestedHeadings);
+    // Add root query container if supplied
+    if (containerID) {
+      allIDs.push(containerID);
+    }
 
     const callback: IntersectionObserverCallback = (entries) => {
       // Add all observer entries to our ref so we can itterate over elements for conditional checks
       entries.forEach((entry) => {
         headingElementsRef.current.set(entry.target.id, entry);
       });
+
+      // Check if query container is inside view, toggles component state
+      if (containerID && headingElementsRef.current.has(containerID)) {
+        const containerObserver = headingElementsRef.current.get(containerID)!;
+        const { top, height } = containerObserver.target.getBoundingClientRect();
+        const diff = (height - Math.abs(top)) / window.innerHeight;
+        setIsVisible(diff >= 1);
+
+        console.log(containerObserver.intersectionRatio);
+      }
 
       // Get the top headings that are visible
       const visibleHeadingsIDs: string[] = [];
@@ -145,24 +158,8 @@ export function TableOfContents({ title, containerID, headingLevels, className }
       }
     });
 
-    // Hide ToC when outside query container
-    const containerObserver = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        setIsVisible(entry.isIntersecting);
-      },
-      {
-        rootMargin: '-100% 0px 0px 0px',
-        threshold: 0,
-      }
-    );
-
-    if (containerID) {
-      containerObserver.observe(queryContainer as Element);
-    }
-
     return () => {
-      (observerRef.current?.disconnect(), containerRef.current?.disconnect());
+      observerRef.current?.disconnect();
     };
   }, [containerID, headingLevels]);
 


### PR DESCRIPTION
## Summary

Added conditional rendering of ToC on mobile to avoid the menu overlapping with unrelated content section, such as the footer

## Related issue

<!-- Use closing keywords here: close(es/d), fix(es/d) & resolve(es/d) -->

- closes #137 

## What was changed

- Added visibility state to ToC on mobile resolutions which is controlled by an intersection observer

## Scope of review

Focus on functionality of different screen sizes and orientations

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
