### PR TITLE
Updated ToC width constraints to avoid content shuffle

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export default async function Privacy() {
   const messages = await getMessages();
   const privacy = messages.privacy as PrivacyMessages;
   return (
-    <main className='relative sm:flex-row gap-4 p-4 md:px-8'>
+    <main className='container mx-auto relative sm:flex-row gap-4 p-4 md:px-8'>
       <TableOfContents containerID='privacy-page' headingLevels={['h2', 'h3', 'h4', 'h5']} />
       <div id='privacy-page' className='flex flex-col gap-12'>
         {privacy.sections.map((data, i) => (

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -161,12 +161,12 @@ export function TableOfContents({ title, containerID, headingLevels, className }
 
   return (
     <aside
-      className={`min-w-48 ${isVisible ? 'opacity-100' : 'max-sm:opacity-0 max-sm:pointer-events-none'} transition duration-100`}
+      className={`w-screen min-w-48 max-w-xs ${isVisible ? 'opacity-100' : 'max-sm:opacity-0 max-sm:pointer-events-none'} transition duration-100`}
     >
       <nav
         className={twMerge(
           `z-10 fixed sm:sticky top-[calc(var(--header-h)+1rem)] max-h-[calc(100svh-var(--header-h)-2rem)]
-          flex flex-col gap-4 panel bg-surface max-sm:inset-4 max-sm:top-auto`,
+          flex flex-col gap-4 panel bg-surface max-sm:inset-2 max-sm:top-auto p-4`,
           className
         )}
       >
@@ -174,7 +174,7 @@ export function TableOfContents({ title, containerID, headingLevels, className }
           <h2 className='text-center'>{title || 'Table of Content'}</h2>
           <span className='sm:hidden'>{!isCollapsed ? <ArrowDownFromLine /> : <ArrowUpFromLine />}</span>
         </span>
-        <div className={`flex flex-col overflow-y-auto text-sm ${isCollapsed ? 'max-sm:hidden' : ''}`}>
+        <ul className={`flex flex-col pr-2 overflow-y-auto text-sm ${isCollapsed ? 'max-sm:hidden' : ''}`}>
           {headings.map((category) => (
             <ToCSection
               key={category.id}
@@ -184,7 +184,7 @@ export function TableOfContents({ title, containerID, headingLevels, className }
               onClick={toggleSection}
             />
           ))}
-        </div>
+        </ul>
       </nav>
     </aside>
   );

--- a/src/components/ui/menus/tableOfContent/ToC.tsx
+++ b/src/components/ui/menus/tableOfContent/ToC.tsx
@@ -161,12 +161,12 @@ export function TableOfContents({ title, containerID, headingLevels, className }
 
   return (
     <aside
-      className={`w-screen min-w-48 max-w-xs ${isVisible ? 'opacity-100' : 'max-sm:opacity-0 max-sm:pointer-events-none'} transition duration-100`}
+      className={` ${isVisible ? 'opacity-100' : 'max-sm:opacity-0 max-sm:pointer-events-none'} transition duration-100`}
     >
       <nav
         className={twMerge(
           `z-10 fixed sm:sticky top-[calc(var(--header-h)+1rem)] max-h-[calc(100svh-var(--header-h)-2rem)]
-          flex flex-col gap-4 panel bg-surface max-sm:inset-2 max-sm:top-auto p-4`,
+          flex flex-col gap-4 panel bg-surface max-sm:inset-2 max-sm:top-auto p-2`,
           className
         )}
       >

--- a/src/components/ui/menus/tableOfContent/ToCSection.tsx
+++ b/src/components/ui/menus/tableOfContent/ToCSection.tsx
@@ -29,17 +29,17 @@ export function ToCSection({ item, activeID, expandedIDs, onClick }: ToCSectionP
 
   return (
     <li
-      className={`pl-2 py-0.5 border-l-2 ${isExpanded ? (isActive ? 'border-primary' : 'border-tertiary') : 'border-panel-border/10'}`}
+      className={`w-fit pl-2 py-0.5 border-l-2 ${isExpanded ? (isActive ? 'border-primary' : 'border-tertiary') : 'border-panel-border/10'}`}
     >
       <Link
         href={`#${item.id}`}
-        className={`${isActive ? 'text-primary font-bold ' : ''} hover:underline`}
+        className={`sm:text-xs md:text-sm break-normal ${isActive ? 'text-primary' : ''} hover:underline`}
         onClick={() => onClick(item.id)}
       >
         {item.label}
       </Link>
-      {isExpanded && item.children && (
-        <ul className='py-2'>
+      {item.children && (
+        <ul className={isExpanded ? `py-2` : 'h-0 overflow-clip'}>
           {item.children.map((child) => (
             <ToCSection key={child.id} item={child} activeID={activeID} expandedIDs={expandedIDs} onClick={onClick} />
           ))}


### PR DESCRIPTION
## Summary

Small improvement to ToC which prevents it from changing sizes when scrolling through content, this should prevent the content shuffling we saw previously

## Related issue

<!-- Use closing keywords here: close(es/d), fix(es/d) & resolve(es/d) -->

- closes #136 

## What was changed

- Added size constraint to privacy page to avoid it growing endlessly
- Modified ToC and ToC Section to inherit its witdth from the largest element, thus preventing content shuffling due to ToC resizing
- Minor responsiveness tweaks to spacings and font sizing  

## Scope of review

Focus two things
- does ToC change width when scrolling through the whole page/section
- what happens when we meet superlong words 

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch