### PR TITLE
Improving footer light theme readability

### DIFF
--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -6,6 +6,7 @@
 
   /* Backgrounds */
   --background: light-dark(hsl(200, 85%, 95%), hsl(219, 37%, 17%));
+  --background-dark: hsl(220, 30%, 10%);
   --surface: light-dark(hsl(from var(--background) h s calc(l - 3)), hsl(from var(--background) h s calc(l + 3)));
   --surface-hover: light-dark(hsl(from var(--background) h s calc(l - 5)), hsl(from var(--background) h s calc(l + 5)));
   --panel: light-dark(hsl(from var(--background) h s calc(l - 8)), hsl(from var(--background) h s calc(l + 8)));
@@ -23,10 +24,14 @@
 
   /* Text */
   --text: light-dark(hsl(270, 5%, 20%), hsl(0, 0%, 100%));
-  --text-input: light-dark(hsl(270, 5%, 20%), hsl(270, 5%, 10%));
   --text-muted: light-dark(hsl(from var(--text) h s calc(l + 20)), hsl(from var(--text) h s calc(l - 20)));
   --text-panel: light-dark(hsl(from var(--text) h s calc(l + 20)), hsl(from var(--text) h s calc(l - 20)));
   --text-surface: light-dark(hsl(from var(--text) h s calc(l + 20)), hsl(from var(--text) h s calc(l - 20)));
+  --text-input: light-dark(hsl(270, 5%, 20%), hsl(270, 5%, 10%));
+  --text-input-muted: light-dark(
+    hsl(from var(--text-input) h s calc(l + 20)),
+    hsl(from var(--text-input) h s calc(l + 30))
+  );
 
   /* Action colors */
   --primary: hsl(200, 100%, 60%);
@@ -98,8 +103,10 @@
   }
 
   footer {
+    @apply flex flex-col gap-16 pt-16;
+
     > div {
-      @apply px-4 py-8 md:px-8 lg:py-16 grid gap-16;
+      @apply px-4 md:px-8 grid gap-16;
     }
 
     a {
@@ -142,6 +149,7 @@
 @theme inline {
   /* Backgrounds */
   --color-background: var(--background);
+  --color-background-dark: var(--background-dark);
   --color-panel-hover: var(--panel-hover);
   --color-panel: var(--panel);
   --color-surface-hover: var(--surface-hover);
@@ -178,6 +186,7 @@
   --color-text: var(--text);
   --color-text-input: var(--text-input);
   --color-text-muted: var(--text-muted);
+  --color-text-input-muted: var(--text-input-muted);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 

--- a/src/components/layout/base/footer.tsx
+++ b/src/components/layout/base/footer.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link';
 export function Footer() {
   const t = useTranslations('layout.footer');
   return (
-    <footer className='bg-black/50'>
+    <footer className='bg-background-dark text-input'>
       <div className='container mx-auto grid-cols-1 lg:grid-cols-2'>
         <div className='flex flex-col gap-4'>
           <h2>{t('followUs.title')}</h2>
@@ -30,7 +30,7 @@ export function Footer() {
             />
             <ScrollText className='m-2' />
           </span>
-          <p className='italic text-text-muted'>{t('newsletter.comingSoon')}</p>
+          <p className='italic text-text-input-muted'>{t('newsletter.comingSoon')}</p>
         </div>
       </div>
       <div className='container mx-auto grid gap-16 grid-cols-2 lg:grid-cols-4'>
@@ -61,7 +61,7 @@ export function Footer() {
               Remove cookie consent
             </button>
           </nav>
-          <p className='italic text-text-muted'>{t('links.comingSoon')}</p>
+          <p className='italic text-text-input-muted'>{t('links.comingSoon')}</p>
         </div>
         <div className='flex flex-col gap-4'>
           <h2>{t('contact.title')}</h2>


### PR DESCRIPTION
## Summary

This PR fixes the footer color readability with light theme

## Related issue

<!-- Use closing keywords here: close(es/d), fix(es/d) & resolve(es/d) -->

- closes #117 

## What was changed

- Added `--background-dark` which is a permanent dark color which will be used in footer, or any other places which requires this dark color
- Added a muted variant of text input color
- Adjusted sizings in footer to avoid too much whitespace

## Scope of review

- Switch between light and dark theme
- Try out different screen sizes
- Check for readability

## Screenshots or additional notes

<img width="1218" height="771" alt="image" src="https://github.com/user-attachments/assets/8d302171-58a4-490e-b52f-4af58f0185de" />


## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
