### PR TITLE
Adds border-box as global default for box-sizing

### DIFF
--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -73,6 +73,13 @@
   html {
     scroll-padding-top: calc(var(--header-h) + 1rem);
     scroll-behavior: smooth;
+    box-sizing: border-box;
+  }
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: inherit;
   }
 
   body {


### PR DESCRIPTION
## Summary

Improve uniformity in box-sizing between all pages and components

## Related issue

<!-- Use closing keywords here: close(es/d), fix(es/d) & resolve(es/d) -->

- closes #149 

## What was changed

This PR makes `box-sizing: "border-box" the default value 

## Checklist
<!-- If a task is not applicable, mark it as completed anyway -->

- [x] I have added or updated tests where relevant
- [x] I have updated relevant documentation
- [x] I have noted any breaking changes, config changes, or migration steps
- [x] This PR targets the `development` branch
